### PR TITLE
Clarify tags field always returns empty list, never null

### DIFF
--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -9,7 +9,7 @@
 | `content` | String | Not null |
 | `createdAt` | LocalDateTime | Not null, auto-set on creation |
 | `updatedAt` | LocalDateTime | Not null, auto-updated on modification |
-| `tags` | List<String> | Not null (can be empty list) |
+| `tags` | List<String> | Not null, always returns empty list `[]` instead of null |
 
 ## Technology Stack
 


### PR DESCRIPTION
## Summary
- Updates spec to clarify that the `tags` field will always return an empty list `[]` instead of null when there are no tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)