### PR TITLE
Downgrade from Java 21 to Java 17

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Notes API is a CRUD Quarkus backend for managing Note entities. It uses PostgreS
 
 ## Tech Stack
 
-- **Java 21** with Quarkus 3.17.2
+- **Java 17** with Quarkus 3.17.2
 - **Hibernate ORM with Panache** - Active Record pattern for entities
 - **Flyway** - Database migrations in `src/main/resources/db/migration/`
 - **REST Assured** - Testing framework

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>


### PR DESCRIPTION
## Summary
- Downgrade Java version from 21 to 17 for broader compatibility
- Updated `pom.xml` maven.compiler.release property
- Updated `CLAUDE.md` to reflect the new Java version

## Test plan
- [x] Verified build succeeds with `mvn package -DskipTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)