### PR TITLE
Migrate Note entity to UUID and configure Dev Services

### DIFF
--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -4,7 +4,7 @@
 
 | Field | Type | Constraints |
 |-------|------|-------------|
-| `id` | Long | Primary key, auto-generated |
+| `id` | UUID | Primary key, auto-generated |
 | `title` | String | Not null |
 | `content` | String | Not null |
 | `createdAt` | LocalDateTime | Not null, auto-set on creation |

--- a/src/main/java/com/example/notes/entity/Note.java
+++ b/src/main/java/com/example/notes/entity/Note.java
@@ -1,20 +1,29 @@
 package com.example.notes.entity;
 
-import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.annotations.UuidGenerator;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Table(name = "note")
-public class Note extends PanacheEntity {
+public class Note extends PanacheEntityBase {
+
+    @Id
+    @GeneratedValue
+    @UuidGenerator
+    public UUID id;
 
     @NotNull
     @Column(nullable = false)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,15 +3,21 @@ quarkus.application.name=notes
 
 # PostgreSQL datasource configuration
 quarkus.datasource.db-kind=postgresql
-quarkus.datasource.username=notes
-quarkus.datasource.password=notes
-quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/notes
+
+# Production database settings
+%prod.quarkus.datasource.username=notes
+%prod.quarkus.datasource.password=notes
+%prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/notes
+
+# Dev mode: Quarkus Dev Services auto-starts a PostgreSQL container via Docker
+# (no explicit JDBC URL needed - Dev Services handles it)
 
 # Hibernate ORM configuration
 quarkus.hibernate-orm.database.generation=none
 
 # Flyway configuration
 quarkus.flyway.migrate-at-start=true
+%dev.quarkus.flyway.clean-at-start=true
 
 # OpenAPI / Swagger UI
 quarkus.smallrye-openapi.info-title=Notes API

--- a/src/main/resources/db/migration/V1__Create_notes_table.sql
+++ b/src/main/resources/db/migration/V1__Create_notes_table.sql
@@ -1,5 +1,5 @@
 CREATE TABLE note (
-    id BIGSERIAL PRIMARY KEY,
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     title VARCHAR(255) NOT NULL,
     content TEXT NOT NULL,
     created_at TIMESTAMP NOT NULL,


### PR DESCRIPTION
## Summary
- Migrate Note entity id from Long to UUID with Hibernate @UuidGenerator
- Update Flyway V1 migration to use UUID primary key with gen_random_uuid()
- Configure Quarkus Dev Services for automatic PostgreSQL container in dev mode
- Add flyway.clean-at-start for dev mode to handle migration schema changes

## Test plan
- [ ] Run `mvn quarkus:dev` and verify Dev Services starts PostgreSQL container
- [ ] Test CRUD operations via Swagger UI at `/q/swagger-ui`
- [ ] Verify Note IDs are now UUIDs in API responses
- [ ] Run `mvn test` to ensure all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)