### PR TITLE
Add POST /notes endpoint with dummy response

### DIFF
--- a/src/main/java/com/example/notes/resource/NoteResource.java
+++ b/src/main/java/com/example/notes/resource/NoteResource.java
@@ -1,0 +1,33 @@
+package com.example.notes.resource;
+
+import com.example.notes.entity.Note;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.UUID;
+
+@Path("/notes")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class NoteResource {
+
+    @POST
+    public Response createNote(Note request) {
+        Note note = new Note();
+        note.id = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        note.title = request != null && request.title != null ? request.title : "Dummy Note";
+        note.content = request != null && request.content != null ? request.content : "Dummy content";
+        LocalDateTime now = LocalDateTime.now();
+        note.createdAt = now;
+        note.updatedAt = now;
+        note.tags = new ArrayList<>();
+
+        return Response.status(Response.Status.CREATED).entity(note).build();
+    }
+}

--- a/src/test/java/com/example/notes/resource/NoteResourceTest.java
+++ b/src/test/java/com/example/notes/resource/NoteResourceTest.java
@@ -1,0 +1,48 @@
+package com.example.notes.resource;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
+@QuarkusTest
+public class NoteResourceTest {
+
+    @Test
+    public void testCreateNote() {
+        String requestBody = "{\"title\": \"Test\", \"content\": \"Content\", \"tags\": []}";
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+        .when()
+            .post("/notes")
+        .then()
+            .statusCode(201)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("title", is("Test"))
+            .body("content", is("Content"))
+            .body("createdAt", notNullValue())
+            .body("updatedAt", notNullValue())
+            .body("tags", notNullValue());
+    }
+
+    @Test
+    public void testCreateNoteWithEmptyBody() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("{}")
+        .when()
+            .post("/notes")
+        .then()
+            .statusCode(201)
+            .contentType(ContentType.JSON)
+            .body("id", notNullValue())
+            .body("title", is("Dummy Note"))
+            .body("content", is("Dummy content"));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `POST /notes` endpoint that returns a `201 Created` status with a dummy Note JSON object
- Implements `NoteResource` class with the endpoint at `/notes`
- Includes REST Assured tests verifying the endpoint behavior

Closes #10

## Test plan

- [x] Run `mvn test -Dtest=NoteResourceTest` - both tests pass
- [ ] Verify endpoint works manually via Swagger UI at `/q/swagger-ui`
- [ ] Review that response matches the expected Note entity schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)