### PR TITLE
Add NoteService with stub implementation

### DIFF
--- a/src/main/java/com/example/notes/resource/NoteResource.java
+++ b/src/main/java/com/example/notes/resource/NoteResource.java
@@ -2,25 +2,20 @@ package com.example.notes.resource;
 
 import com.example.notes.api.NoteApi;
 import com.example.notes.entity.Note;
+import com.example.notes.service.NoteService;
 import jakarta.ws.rs.core.Response;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.UUID;
 
 public class NoteResource implements NoteApi {
 
+    private final NoteService noteService;
+
+    public NoteResource(NoteService noteService) {
+        this.noteService = noteService;
+    }
+
     @Override
     public Response createNote(Note request) {
-        Note note = new Note();
-        note.id = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
-        note.title = request != null && request.title != null ? request.title : "Dummy Note";
-        note.content = request != null && request.content != null ? request.content : "Dummy content";
-        LocalDateTime now = LocalDateTime.now();
-        note.createdAt = now;
-        note.updatedAt = now;
-        note.tags = new ArrayList<>();
-
+        Note note = noteService.createNote(request);
         return Response.status(Response.Status.CREATED).entity(note).build();
     }
 }

--- a/src/main/java/com/example/notes/service/NoteService.java
+++ b/src/main/java/com/example/notes/service/NoteService.java
@@ -1,0 +1,25 @@
+package com.example.notes.service;
+
+import com.example.notes.entity.Note;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.UUID;
+
+@ApplicationScoped
+public class NoteService {
+
+    public Note createNote(Note request) {
+        Note note = new Note();
+        note.id = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        note.title = request != null && request.title != null ? request.title : "Dummy Note";
+        note.content = request != null && request.content != null ? request.content : "Dummy content";
+        LocalDateTime now = LocalDateTime.now();
+        note.createdAt = now;
+        note.updatedAt = now;
+        note.tags = new ArrayList<>();
+
+        return note;
+    }
+}


### PR DESCRIPTION
## Summary

- Create `NoteService` as `@ApplicationScoped` CDI bean in `com.example.notes.service` package
- Move dummy note creation logic from `NoteResource` to `NoteService`
- Inject `NoteService` into `NoteResource` via constructor injection

## Test plan

- [x] All existing tests pass (`mvn test`)
- [ ] Verify endpoint still returns expected dummy note response

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)