### PR TITLE
Implement Request DTOs with Bean Validation for REST API

### DIFF
--- a/src/main/java/com/example/notes/api/NoteApi.java
+++ b/src/main/java/com/example/notes/api/NoteApi.java
@@ -1,6 +1,7 @@
 package com.example.notes.api;
 
-import com.example.notes.entity.Note;
+import com.example.notes.dto.CreateNoteRequest;
+import jakarta.validation.Valid;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -14,5 +15,5 @@ import jakarta.ws.rs.core.Response;
 public interface NoteApi {
 
     @POST
-    Response createNote(Note request);
+    Response createNote(@Valid CreateNoteRequest request);
 }

--- a/src/main/java/com/example/notes/dto/CreateNoteRequest.java
+++ b/src/main/java/com/example/notes/dto/CreateNoteRequest.java
@@ -1,0 +1,16 @@
+package com.example.notes.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+public record CreateNoteRequest(
+    @NotBlank(message = "Title is required")
+    String title,
+
+    @NotBlank(message = "Content is required")
+    String content,
+
+    List<String> tags
+) {
+}

--- a/src/main/java/com/example/notes/dto/NoteResponse.java
+++ b/src/main/java/com/example/notes/dto/NoteResponse.java
@@ -1,0 +1,27 @@
+package com.example.notes.dto;
+
+import com.example.notes.entity.Note;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record NoteResponse(
+    UUID id,
+    String title,
+    String content,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
+    List<String> tags
+) {
+    public static NoteResponse from(Note note) {
+        return new NoteResponse(
+            note.id,
+            note.title,
+            note.content,
+            note.createdAt,
+            note.updatedAt,
+            note.tags
+        );
+    }
+}

--- a/src/main/java/com/example/notes/dto/UpdateNoteRequest.java
+++ b/src/main/java/com/example/notes/dto/UpdateNoteRequest.java
@@ -1,0 +1,16 @@
+package com.example.notes.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+public record UpdateNoteRequest(
+    @NotBlank(message = "Title is required")
+    String title,
+
+    @NotBlank(message = "Content is required")
+    String content,
+
+    List<String> tags
+) {
+}

--- a/src/main/java/com/example/notes/resource/NoteResource.java
+++ b/src/main/java/com/example/notes/resource/NoteResource.java
@@ -1,6 +1,8 @@
 package com.example.notes.resource;
 
 import com.example.notes.api.NoteApi;
+import com.example.notes.dto.CreateNoteRequest;
+import com.example.notes.dto.NoteResponse;
 import com.example.notes.entity.Note;
 import com.example.notes.service.NoteService;
 import jakarta.ws.rs.core.Response;
@@ -14,8 +16,8 @@ public class NoteResource implements NoteApi {
     }
 
     @Override
-    public Response createNote(Note request) {
+    public Response createNote(CreateNoteRequest request) {
         Note note = noteService.createNote(request);
-        return Response.status(Response.Status.CREATED).entity(note).build();
+        return Response.status(Response.Status.CREATED).entity(NoteResponse.from(note)).build();
     }
 }

--- a/src/main/java/com/example/notes/service/NoteService.java
+++ b/src/main/java/com/example/notes/service/NoteService.java
@@ -1,5 +1,6 @@
 package com.example.notes.service;
 
+import com.example.notes.dto.CreateNoteRequest;
 import com.example.notes.entity.Note;
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -10,15 +11,15 @@ import java.util.UUID;
 @ApplicationScoped
 public class NoteService {
 
-    public Note createNote(Note request) {
+    public Note createNote(CreateNoteRequest request) {
         Note note = new Note();
         note.id = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
-        note.title = request != null && request.title != null ? request.title : "Dummy Note";
-        note.content = request != null && request.content != null ? request.content : "Dummy content";
+        note.title = request.title();
+        note.content = request.content();
         LocalDateTime now = LocalDateTime.now();
         note.createdAt = now;
         note.updatedAt = now;
-        note.tags = new ArrayList<>();
+        note.tags = request.tags() != null ? new ArrayList<>(request.tags()) : new ArrayList<>();
 
         return note;
     }

--- a/src/test/java/com/example/notes/resource/NoteResourceTest.java
+++ b/src/test/java/com/example/notes/resource/NoteResourceTest.java
@@ -5,6 +5,7 @@ import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 
@@ -32,17 +33,134 @@ public class NoteResourceTest {
     }
 
     @Test
-    public void testCreateNoteWithEmptyBody() {
+    public void testCreateNoteWithEmptyBodyReturnsBadRequest() {
         given()
             .contentType(ContentType.JSON)
             .body("{}")
         .when()
             .post("/v1/notes")
         .then()
+            .statusCode(400);
+    }
+
+    @Test
+    public void testCreateNoteWithNullTitleReturnsBadRequest() {
+        String requestBody = "{\"content\": \"Content\", \"tags\": []}";
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+        .when()
+            .post("/v1/notes")
+        .then()
+            .statusCode(400)
+            .body("violations.field", hasItem("createNote.request.title"))
+            .body("violations.message", hasItem("Title is required"));
+    }
+
+    @Test
+    public void testCreateNoteWithEmptyTitleReturnsBadRequest() {
+        String requestBody = "{\"title\": \"\", \"content\": \"Content\", \"tags\": []}";
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+        .when()
+            .post("/v1/notes")
+        .then()
+            .statusCode(400)
+            .body("violations.field", hasItem("createNote.request.title"))
+            .body("violations.message", hasItem("Title is required"));
+    }
+
+    @Test
+    public void testCreateNoteWithBlankTitleReturnsBadRequest() {
+        String requestBody = "{\"title\": \"   \", \"content\": \"Content\", \"tags\": []}";
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+        .when()
+            .post("/v1/notes")
+        .then()
+            .statusCode(400)
+            .body("violations.field", hasItem("createNote.request.title"))
+            .body("violations.message", hasItem("Title is required"));
+    }
+
+    @Test
+    public void testCreateNoteWithNullContentReturnsBadRequest() {
+        String requestBody = "{\"title\": \"Test\", \"tags\": []}";
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+        .when()
+            .post("/v1/notes")
+        .then()
+            .statusCode(400)
+            .body("violations.field", hasItem("createNote.request.content"))
+            .body("violations.message", hasItem("Content is required"));
+    }
+
+    @Test
+    public void testCreateNoteWithEmptyContentReturnsBadRequest() {
+        String requestBody = "{\"title\": \"Test\", \"content\": \"\", \"tags\": []}";
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+        .when()
+            .post("/v1/notes")
+        .then()
+            .statusCode(400)
+            .body("violations.field", hasItem("createNote.request.content"))
+            .body("violations.message", hasItem("Content is required"));
+    }
+
+    @Test
+    public void testCreateNoteWithBlankContentReturnsBadRequest() {
+        String requestBody = "{\"title\": \"Test\", \"content\": \"   \", \"tags\": []}";
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+        .when()
+            .post("/v1/notes")
+        .then()
+            .statusCode(400)
+            .body("violations.field", hasItem("createNote.request.content"))
+            .body("violations.message", hasItem("Content is required"));
+    }
+
+    @Test
+    public void testCreateNoteWithTags() {
+        String requestBody = "{\"title\": \"Test\", \"content\": \"Content\", \"tags\": [\"tag1\", \"tag2\"]}";
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+        .when()
+            .post("/v1/notes")
+        .then()
             .statusCode(201)
             .contentType(ContentType.JSON)
-            .body("id", notNullValue())
-            .body("title", is("Dummy Note"))
-            .body("content", is("Dummy content"));
+            .body("tags", hasItem("tag1"))
+            .body("tags", hasItem("tag2"));
+    }
+
+    @Test
+    public void testCreateNoteWithoutTagsUsesEmptyList() {
+        String requestBody = "{\"title\": \"Test\", \"content\": \"Content\"}";
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+        .when()
+            .post("/v1/notes")
+        .then()
+            .statusCode(201)
+            .contentType(ContentType.JSON)
+            .body("tags.size()", is(0));
     }
 }


### PR DESCRIPTION
## Summary

- Add `CreateNoteRequest`, `UpdateNoteRequest`, and `NoteResponse` DTOs using Java records
- Implement Bean Validation with `@NotBlank` on `title` and `content` fields
- Add `@Valid` annotation on POST endpoint to enable validation
- Remove fallback/dummy value logic from service layer
- Update tests to verify 400 Bad Request responses for invalid input

## Test plan

- [x] POST with valid data returns 201 Created
- [x] POST with empty body returns 400 Bad Request
- [x] POST with null/empty/blank title returns 400 with validation message
- [x] POST with null/empty/blank content returns 400 with validation message
- [x] POST with tags preserves them in response
- [x] POST without tags returns empty list
- [x] All 10 tests pass

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)