### PR TITLE
Add NoteRepository with Panache Repository pattern

### DIFF
--- a/src/main/java/com/example/notes/repository/NoteRepository.java
+++ b/src/main/java/com/example/notes/repository/NoteRepository.java
@@ -1,0 +1,11 @@
+package com.example.notes.repository;
+
+import com.example.notes.entity.Note;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.UUID;
+
+@ApplicationScoped
+public class NoteRepository implements PanacheRepositoryBase<Note, UUID> {
+}

--- a/src/main/java/com/example/notes/service/NoteService.java
+++ b/src/main/java/com/example/notes/service/NoteService.java
@@ -2,25 +2,29 @@ package com.example.notes.service;
 
 import com.example.notes.dto.CreateNoteRequest;
 import com.example.notes.entity.Note;
+import com.example.notes.repository.NoteRepository;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.UUID;
 
 @ApplicationScoped
 public class NoteService {
 
+    private final NoteRepository noteRepository;
+
+    public NoteService(NoteRepository noteRepository) {
+        this.noteRepository = noteRepository;
+    }
+
+    @Transactional
     public Note createNote(CreateNoteRequest request) {
         Note note = new Note();
-        note.id = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
         note.title = request.title();
         note.content = request.content();
-        LocalDateTime now = LocalDateTime.now();
-        note.createdAt = now;
-        note.updatedAt = now;
         note.tags = request.tags() != null ? new ArrayList<>(request.tags()) : new ArrayList<>();
 
+        noteRepository.persist(note);
         return note;
     }
 }

--- a/src/test/java/com/example/notes/service/NoteServiceTest.java
+++ b/src/test/java/com/example/notes/service/NoteServiceTest.java
@@ -1,0 +1,64 @@
+package com.example.notes.service;
+
+import com.example.notes.dto.CreateNoteRequest;
+import com.example.notes.entity.Note;
+import com.example.notes.repository.NoteRepository;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class NoteServiceTest {
+
+    @Inject
+    NoteService noteService;
+
+    @Inject
+    NoteRepository noteRepository;
+
+    @Test
+    public void testCreateNotePersistsToDatabase() {
+        CreateNoteRequest request = new CreateNoteRequest("Test Title", "Test Content", List.of("tag1", "tag2"));
+
+        Note createdNote = noteService.createNote(request);
+
+        assertNotNull(createdNote.id);
+        assertEquals("Test Title", createdNote.title);
+        assertEquals("Test Content", createdNote.content);
+        assertEquals(List.of("tag1", "tag2"), createdNote.tags);
+        assertNotNull(createdNote.createdAt);
+        assertNotNull(createdNote.updatedAt);
+
+        Note foundNote = noteRepository.findById(createdNote.id);
+        assertNotNull(foundNote);
+        assertEquals(createdNote.id, foundNote.id);
+        assertEquals("Test Title", foundNote.title);
+        assertEquals("Test Content", foundNote.content);
+    }
+
+    @Test
+    public void testCreateNoteWithNullTagsUsesEmptyList() {
+        CreateNoteRequest request = new CreateNoteRequest("Test Title", "Test Content", null);
+
+        Note createdNote = noteService.createNote(request);
+
+        assertNotNull(createdNote.tags);
+        assertTrue(createdNote.tags.isEmpty());
+    }
+
+    @Test
+    public void testCreateNoteWithEmptyTagsList() {
+        CreateNoteRequest request = new CreateNoteRequest("Test Title", "Test Content", List.of());
+
+        Note createdNote = noteService.createNote(request);
+
+        assertNotNull(createdNote.tags);
+        assertTrue(createdNote.tags.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- Created `NoteRepository` class extending `PanacheRepositoryBase<Note, UUID>`
- Updated `NoteService` to use constructor injection with `NoteRepository`
- `NoteService.createNote()` now persists notes to the database via the repository
- Added `NoteServiceTest` with integration tests for the service

## Test plan
- [x] All 13 existing tests pass
- [x] Added 3 new tests in `NoteServiceTest`:
  - `testCreateNotePersistsToDatabase` - verifies note is persisted and retrievable
  - `testCreateNoteWithNullTagsUsesEmptyList` - verifies null tags handling
  - `testCreateNoteWithEmptyTagsList` - verifies empty tags list handling

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)