### PR TITLE
Add HTTP file test for local API testing

### DIFF
--- a/requests.http
+++ b/requests.http
@@ -1,0 +1,33 @@
+### Notes API - Local Development Testing
+### Start the API with: mvn quarkus:dev
+
+### Get all notes
+GET http://localhost:8080/v1/notes
+Accept: application/json
+
+### Create a new note
+POST http://localhost:8080/v1/notes
+Content-Type: application/json
+
+{
+  "title": "My First Note",
+  "content": "This is the content of my first note.",
+  "tags": ["example", "test"]
+}
+
+### Get a note by ID (replace {id} with actual UUID)
+GET http://localhost:8080/v1/notes/{{id}}
+Accept: application/json
+
+### Update a note (replace {id} with actual UUID)
+PUT http://localhost:8080/v1/notes/{{id}}
+Content-Type: application/json
+
+{
+  "title": "Updated Note Title",
+  "content": "This is the updated content.",
+  "tags": ["updated", "example"]
+}
+
+### Delete a note (replace {id} with actual UUID)
+DELETE http://localhost:8080/v1/notes/{{id}}


### PR DESCRIPTION
## Summary
- Add `requests.http` file with sample HTTP requests for testing the Notes API locally
- Includes requests for all CRUD operations (GET all, POST create, GET by ID, PUT update, DELETE)
- Compatible with IntelliJ IDEA HTTP Client and VS Code REST Client

## Test plan
- [ ] Start the API with `mvn quarkus:dev`
- [ ] Run the POST request to create a note
- [ ] Run the GET all request to verify the note was created

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)