### PR TITLE
Add unit tests for mappers and service layer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,11 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- H2 for testing -->
         <dependency>

--- a/src/test/java/com/example/notes/application/service/NoteApplicationServiceTest.java
+++ b/src/test/java/com/example/notes/application/service/NoteApplicationServiceTest.java
@@ -1,0 +1,98 @@
+package com.example.notes.application.service;
+
+import com.example.notes.application.port.in.CreateNoteUseCase.CreateNoteCommand;
+import com.example.notes.application.port.out.NoteRepository;
+import com.example.notes.domain.model.Note;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@QuarkusTest
+class NoteApplicationServiceTest {
+
+    @Inject
+    NoteApplicationService service;
+
+    @InjectMock
+    NoteRepository noteRepository;
+
+    @Test
+    void createNote_withValidCommand_savesNoteToRepository() {
+        CreateNoteCommand command = new CreateNoteCommand("Title", "Content", List.of("tag1", "tag2"));
+        when(noteRepository.save(any(Note.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Note result = service.createNote(command);
+
+        assertNotNull(result);
+        assertEquals("Title", result.title());
+        assertEquals("Content", result.content());
+        assertEquals(List.of("tag1", "tag2"), result.tags());
+        verify(noteRepository, times(1)).save(any(Note.class));
+    }
+
+    @Test
+    void createNote_passesCorrectNoteToRepository() {
+        CreateNoteCommand command = new CreateNoteCommand("Title", "Content", List.of("tag1"));
+        ArgumentCaptor<Note> noteCaptor = ArgumentCaptor.forClass(Note.class);
+        when(noteRepository.save(any(Note.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.createNote(command);
+
+        verify(noteRepository).save(noteCaptor.capture());
+        Note savedNote = noteCaptor.getValue();
+        assertEquals("Title", savedNote.title());
+        assertEquals("Content", savedNote.content());
+        assertEquals(List.of("tag1"), savedNote.tags());
+    }
+
+    @Test
+    void createNote_withNullTags_createsNoteWithEmptyTags() {
+        CreateNoteCommand command = new CreateNoteCommand("Title", "Content", null);
+        when(noteRepository.save(any(Note.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Note result = service.createNote(command);
+
+        assertNotNull(result.tags());
+        assertTrue(result.tags().isEmpty());
+    }
+
+    @Test
+    void createNote_generatesUniqueIdForEachCall() {
+        CreateNoteCommand command = new CreateNoteCommand("Title", "Content", List.of());
+        when(noteRepository.save(any(Note.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Note result1 = service.createNote(command);
+        Note result2 = service.createNote(command);
+
+        assertNotEquals(result1.id(), result2.id());
+    }
+
+    @Test
+    void createNote_setsCreatedAtAndUpdatedAtToSameValue() {
+        CreateNoteCommand command = new CreateNoteCommand("Title", "Content", List.of());
+        when(noteRepository.save(any(Note.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Note result = service.createNote(command);
+
+        assertEquals(result.createdAt(), result.updatedAt());
+    }
+
+    @Test
+    void createNote_returnsNoteSavedByRepository() {
+        CreateNoteCommand command = new CreateNoteCommand("Title", "Content", List.of());
+        Note savedNote = Note.create("Title", "Content", List.of());
+        when(noteRepository.save(any(Note.class))).thenReturn(savedNote);
+
+        Note result = service.createNote(command);
+
+        assertEquals(savedNote, result);
+    }
+}

--- a/src/test/java/com/example/notes/infrastructure/adapter/in/rest/mapper/NoteRestMapperTest.java
+++ b/src/test/java/com/example/notes/infrastructure/adapter/in/rest/mapper/NoteRestMapperTest.java
@@ -1,0 +1,100 @@
+package com.example.notes.infrastructure.adapter.in.rest.mapper;
+
+import com.example.notes.application.port.in.CreateNoteUseCase.CreateNoteCommand;
+import com.example.notes.domain.model.Note;
+import com.example.notes.infrastructure.adapter.in.rest.dto.CreateNoteRequest;
+import com.example.notes.infrastructure.adapter.in.rest.dto.NoteResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NoteRestMapperTest {
+
+    private NoteRestMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new NoteRestMapper();
+    }
+
+    @Test
+    void toCommand_withValidRequest_createsCommand() {
+        CreateNoteRequest request = new CreateNoteRequest("Title", "Content", List.of("tag1", "tag2"));
+
+        CreateNoteCommand command = mapper.toCommand(request);
+
+        assertEquals("Title", command.title());
+        assertEquals("Content", command.content());
+        assertEquals(List.of("tag1", "tag2"), command.tags());
+    }
+
+    @Test
+    void toCommand_withNullTags_preservesNullTags() {
+        CreateNoteRequest request = new CreateNoteRequest("Title", "Content", null);
+
+        CreateNoteCommand command = mapper.toCommand(request);
+
+        assertEquals("Title", command.title());
+        assertEquals("Content", command.content());
+        assertNull(command.tags());
+    }
+
+    @Test
+    void toCommand_withEmptyTags_preservesEmptyTags() {
+        CreateNoteRequest request = new CreateNoteRequest("Title", "Content", List.of());
+
+        CreateNoteCommand command = mapper.toCommand(request);
+
+        assertEquals("Title", command.title());
+        assertEquals("Content", command.content());
+        assertTrue(command.tags().isEmpty());
+    }
+
+    @Test
+    void toResponse_withValidNote_createsResponse() {
+        Note note = Note.create("Title", "Content", List.of("tag1", "tag2"));
+
+        NoteResponse response = mapper.toResponse(note);
+
+        assertEquals(note.id().value(), response.id());
+        assertEquals("Title", response.title());
+        assertEquals("Content", response.content());
+        assertEquals(note.createdAt(), response.createdAt());
+        assertEquals(note.updatedAt(), response.updatedAt());
+        assertEquals(List.of("tag1", "tag2"), response.tags());
+    }
+
+    @Test
+    void toResponse_withNullTags_returnsEmptyTagsList() {
+        Note note = Note.create("Title", "Content", null);
+
+        NoteResponse response = mapper.toResponse(note);
+
+        assertNotNull(response.tags());
+        assertTrue(response.tags().isEmpty());
+    }
+
+    @Test
+    void toResponse_preservesUuidFromNote() {
+        Note note = Note.create("Title", "Content", List.of());
+
+        NoteResponse response = mapper.toResponse(note);
+
+        assertNotNull(response.id());
+        assertEquals(note.id().value(), response.id());
+    }
+
+    @Test
+    void toResponse_preservesTimestampsFromNote() {
+        Note note = Note.create("Title", "Content", List.of());
+
+        NoteResponse response = mapper.toResponse(note);
+
+        assertEquals(note.createdAt(), response.createdAt());
+        assertEquals(note.updatedAt(), response.updatedAt());
+        assertEquals(response.createdAt(), response.updatedAt());
+    }
+}

--- a/src/test/java/com/example/notes/infrastructure/adapter/out/persistence/mapper/NotePersistenceMapperTest.java
+++ b/src/test/java/com/example/notes/infrastructure/adapter/out/persistence/mapper/NotePersistenceMapperTest.java
@@ -1,0 +1,109 @@
+package com.example.notes.infrastructure.adapter.out.persistence.mapper;
+
+import com.example.notes.domain.model.Note;
+import com.example.notes.domain.model.NoteId;
+import com.example.notes.infrastructure.adapter.out.persistence.NoteJpaEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NotePersistenceMapperTest {
+
+    private NotePersistenceMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new NotePersistenceMapper();
+    }
+
+    @Test
+    void toNewJpaEntity_withValidNote_createsEntity() {
+        Note note = Note.create("Title", "Content", List.of("tag1", "tag2"));
+
+        NoteJpaEntity entity = mapper.toNewJpaEntity(note);
+
+        assertEquals("Title", entity.title);
+        assertEquals("Content", entity.content);
+        assertEquals(note.createdAt(), entity.createdAt);
+        assertEquals(note.updatedAt(), entity.updatedAt);
+        assertEquals(List.of("tag1", "tag2"), entity.tags);
+    }
+
+    @Test
+    void toNewJpaEntity_withNullTags_createsEntityWithEmptyTags() {
+        Note note = Note.create("Title", "Content", null);
+
+        NoteJpaEntity entity = mapper.toNewJpaEntity(note);
+
+        assertNotNull(entity.tags);
+        assertTrue(entity.tags.isEmpty());
+    }
+
+    @Test
+    void toNewJpaEntity_doesNotSetId() {
+        Note note = Note.create("Title", "Content", List.of());
+
+        NoteJpaEntity entity = mapper.toNewJpaEntity(note);
+
+        assertNull(entity.id);
+    }
+
+    @Test
+    void toDomainEntity_withValidEntity_createsDomainNote() {
+        NoteJpaEntity entity = new NoteJpaEntity();
+        entity.id = UUID.randomUUID();
+        entity.title = "Title";
+        entity.content = "Content";
+        entity.createdAt = LocalDateTime.now().minusHours(1);
+        entity.updatedAt = LocalDateTime.now();
+        entity.tags = List.of("tag1", "tag2");
+
+        Note note = mapper.toDomainEntity(entity);
+
+        assertEquals(entity.id, note.id().value());
+        assertEquals("Title", note.title());
+        assertEquals("Content", note.content());
+        assertEquals(entity.createdAt, note.createdAt());
+        assertEquals(entity.updatedAt, note.updatedAt());
+        assertEquals(List.of("tag1", "tag2"), note.tags());
+    }
+
+    @Test
+    void toDomainEntity_preservesTimestampDifference() {
+        NoteJpaEntity entity = new NoteJpaEntity();
+        entity.id = UUID.randomUUID();
+        entity.title = "Title";
+        entity.content = "Content";
+        entity.createdAt = LocalDateTime.of(2024, 1, 1, 10, 0);
+        entity.updatedAt = LocalDateTime.of(2024, 1, 2, 15, 30);
+        entity.tags = List.of();
+
+        Note note = mapper.toDomainEntity(entity);
+
+        assertNotEquals(note.createdAt(), note.updatedAt());
+        assertEquals(entity.createdAt, note.createdAt());
+        assertEquals(entity.updatedAt, note.updatedAt());
+    }
+
+    @Test
+    void roundTrip_preservesData() {
+        Note originalNote = Note.create("Title", "Content", List.of("tag1", "tag2"));
+
+        NoteJpaEntity entity = mapper.toNewJpaEntity(originalNote);
+        entity.id = UUID.randomUUID();
+
+        Note reconstitutedNote = mapper.toDomainEntity(entity);
+
+        assertEquals(entity.id, reconstitutedNote.id().value());
+        assertEquals(originalNote.title(), reconstitutedNote.title());
+        assertEquals(originalNote.content(), reconstitutedNote.content());
+        assertEquals(originalNote.createdAt(), reconstitutedNote.createdAt());
+        assertEquals(originalNote.updatedAt(), reconstitutedNote.updatedAt());
+        assertEquals(originalNote.tags(), reconstitutedNote.tags());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `NoteRestMapperTest` with 7 tests covering DTO-to-command and note-to-response mapping
- Add `NotePersistenceMapperTest` with 6 tests for domain-to-JPA and JPA-to-domain mapping
- Add `NoteApplicationServiceTest` with 6 tests using `@InjectMock` for mocked repository
- Add `quarkus-junit5-mockito` dependency for Mockito integration

## Test plan
- [x] All 40 tests pass (`mvn test`)
- [x] New unit tests cover mapper and service layers
- [x] Mockito integration works with Quarkus test framework

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test suite with comprehensive unit tests covering core application services, REST API mapping, and data persistence layers to enhance system reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->