### PR TITLE
Implement DELETE /v1/notes/{id} endpoint

### DIFF
--- a/src/main/java/com/example/notes/application/port/in/DeleteNoteUseCase.java
+++ b/src/main/java/com/example/notes/application/port/in/DeleteNoteUseCase.java
@@ -1,0 +1,8 @@
+package com.example.notes.application.port.in;
+
+import java.util.UUID;
+
+public interface DeleteNoteUseCase {
+
+    void deleteNote(UUID id);
+}

--- a/src/main/java/com/example/notes/application/port/out/NoteRepository.java
+++ b/src/main/java/com/example/notes/application/port/out/NoteRepository.java
@@ -1,8 +1,13 @@
 package com.example.notes.application.port.out;
 
 import com.example.notes.domain.model.Note;
+import com.example.notes.domain.model.NoteId;
 
 public interface NoteRepository {
 
     Note save(Note note);
+
+    boolean existsById(NoteId id);
+
+    void deleteById(NoteId id);
 }

--- a/src/main/java/com/example/notes/application/service/NoteApplicationService.java
+++ b/src/main/java/com/example/notes/application/service/NoteApplicationService.java
@@ -1,13 +1,18 @@
 package com.example.notes.application.service;
 
 import com.example.notes.application.port.in.CreateNoteUseCase;
+import com.example.notes.application.port.in.DeleteNoteUseCase;
 import com.example.notes.application.port.out.NoteRepository;
+import com.example.notes.domain.exception.NoteNotFoundException;
 import com.example.notes.domain.model.Note;
+import com.example.notes.domain.model.NoteId;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 
+import java.util.UUID;
+
 @ApplicationScoped
-public class NoteApplicationService implements CreateNoteUseCase {
+public class NoteApplicationService implements CreateNoteUseCase, DeleteNoteUseCase {
 
     private final NoteRepository noteRepository;
 
@@ -20,5 +25,15 @@ public class NoteApplicationService implements CreateNoteUseCase {
     public Note createNote(CreateNoteCommand command) {
         Note note = Note.create(command.title(), command.content(), command.tags());
         return noteRepository.save(note);
+    }
+
+    @Override
+    @Transactional
+    public void deleteNote(UUID id) {
+        NoteId noteId = NoteId.of(id);
+        if (!noteRepository.existsById(noteId)) {
+            throw new NoteNotFoundException(id);
+        }
+        noteRepository.deleteById(noteId);
     }
 }

--- a/src/main/java/com/example/notes/domain/exception/NoteNotFoundException.java
+++ b/src/main/java/com/example/notes/domain/exception/NoteNotFoundException.java
@@ -1,0 +1,10 @@
+package com.example.notes.domain.exception;
+
+import java.util.UUID;
+
+public class NoteNotFoundException extends RuntimeException {
+
+    public NoteNotFoundException(UUID id) {
+        super("Note not found with id: " + id);
+    }
+}

--- a/src/main/java/com/example/notes/infrastructure/adapter/in/rest/NoteNotFoundExceptionMapper.java
+++ b/src/main/java/com/example/notes/infrastructure/adapter/in/rest/NoteNotFoundExceptionMapper.java
@@ -1,0 +1,20 @@
+package com.example.notes.infrastructure.adapter.in.rest;
+
+import com.example.notes.domain.exception.NoteNotFoundException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class NoteNotFoundExceptionMapper implements ExceptionMapper<NoteNotFoundException> {
+
+    @Override
+    public Response toResponse(NoteNotFoundException exception) {
+        return Response.status(Response.Status.NOT_FOUND)
+                .entity(new ErrorResponse(exception.getMessage()))
+                .build();
+    }
+
+    public record ErrorResponse(String message) {
+    }
+}

--- a/src/main/java/com/example/notes/infrastructure/adapter/in/rest/NoteRestAdapter.java
+++ b/src/main/java/com/example/notes/infrastructure/adapter/in/rest/NoteRestAdapter.java
@@ -1,17 +1,22 @@
 package com.example.notes.infrastructure.adapter.in.rest;
 
 import com.example.notes.application.port.in.CreateNoteUseCase;
+import com.example.notes.application.port.in.DeleteNoteUseCase;
 import com.example.notes.domain.model.Note;
 import com.example.notes.infrastructure.adapter.in.rest.dto.CreateNoteRequest;
 import com.example.notes.infrastructure.adapter.in.rest.dto.NoteResponse;
 import com.example.notes.infrastructure.adapter.in.rest.mapper.NoteRestMapper;
 import jakarta.validation.Valid;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+
+import java.util.UUID;
 
 @Path("/v1/notes")
 @Produces(MediaType.APPLICATION_JSON)
@@ -19,10 +24,12 @@ import jakarta.ws.rs.core.Response;
 public class NoteRestAdapter {
 
     private final CreateNoteUseCase createNoteUseCase;
+    private final DeleteNoteUseCase deleteNoteUseCase;
     private final NoteRestMapper mapper;
 
-    public NoteRestAdapter(CreateNoteUseCase createNoteUseCase, NoteRestMapper mapper) {
+    public NoteRestAdapter(CreateNoteUseCase createNoteUseCase, DeleteNoteUseCase deleteNoteUseCase, NoteRestMapper mapper) {
         this.createNoteUseCase = createNoteUseCase;
+        this.deleteNoteUseCase = deleteNoteUseCase;
         this.mapper = mapper;
     }
 
@@ -31,5 +38,12 @@ public class NoteRestAdapter {
         Note note = createNoteUseCase.createNote(mapper.toCommand(request));
         NoteResponse response = mapper.toResponse(note);
         return Response.status(Response.Status.CREATED).entity(response).build();
+    }
+
+    @DELETE
+    @Path("/{id}")
+    public Response deleteNote(@PathParam("id") UUID id) {
+        deleteNoteUseCase.deleteNote(id);
+        return Response.noContent().build();
     }
 }

--- a/src/main/java/com/example/notes/infrastructure/adapter/out/persistence/JpaNoteRepository.java
+++ b/src/main/java/com/example/notes/infrastructure/adapter/out/persistence/JpaNoteRepository.java
@@ -2,6 +2,7 @@ package com.example.notes.infrastructure.adapter.out.persistence;
 
 import com.example.notes.application.port.out.NoteRepository;
 import com.example.notes.domain.model.Note;
+import com.example.notes.domain.model.NoteId;
 import com.example.notes.infrastructure.adapter.out.persistence.mapper.NotePersistenceMapper;
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -19,5 +20,15 @@ public class JpaNoteRepository implements NoteRepository {
         NoteJpaEntity entity = mapper.toNewJpaEntity(note);
         entity.persist();
         return mapper.toDomainEntity(entity);
+    }
+
+    @Override
+    public boolean existsById(NoteId id) {
+        return NoteJpaEntity.findByIdOptional(id.value()).isPresent();
+    }
+
+    @Override
+    public void deleteById(NoteId id) {
+        NoteJpaEntity.deleteById(id.value());
     }
 }

--- a/src/test/java/com/example/notes/application/service/NoteApplicationServiceDeleteTest.java
+++ b/src/test/java/com/example/notes/application/service/NoteApplicationServiceDeleteTest.java
@@ -1,0 +1,64 @@
+package com.example.notes.application.service;
+
+import com.example.notes.application.port.out.NoteRepository;
+import com.example.notes.domain.exception.NoteNotFoundException;
+import com.example.notes.domain.model.NoteId;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@QuarkusTest
+class NoteApplicationServiceDeleteTest {
+
+    @Inject
+    NoteApplicationService service;
+
+    @InjectMock
+    NoteRepository noteRepository;
+
+    @Test
+    void deleteNote_whenNoteExists_deletesNote() {
+        UUID noteId = UUID.randomUUID();
+        when(noteRepository.existsById(any(NoteId.class))).thenReturn(true);
+
+        service.deleteNote(noteId);
+
+        ArgumentCaptor<NoteId> idCaptor = ArgumentCaptor.forClass(NoteId.class);
+        verify(noteRepository).deleteById(idCaptor.capture());
+        assertEquals(noteId, idCaptor.getValue().value());
+    }
+
+    @Test
+    void deleteNote_whenNoteDoesNotExist_throwsNoteNotFoundException() {
+        UUID noteId = UUID.randomUUID();
+        when(noteRepository.existsById(any(NoteId.class))).thenReturn(false);
+
+        NoteNotFoundException exception = assertThrows(
+            NoteNotFoundException.class,
+            () -> service.deleteNote(noteId)
+        );
+
+        assertEquals("Note not found with id: " + noteId, exception.getMessage());
+        verify(noteRepository, never()).deleteById(any(NoteId.class));
+    }
+
+    @Test
+    void deleteNote_checksExistenceBeforeDeleting() {
+        UUID noteId = UUID.randomUUID();
+        when(noteRepository.existsById(any(NoteId.class))).thenReturn(true);
+
+        service.deleteNote(noteId);
+
+        var inOrder = inOrder(noteRepository);
+        inOrder.verify(noteRepository).existsById(any(NoteId.class));
+        inOrder.verify(noteRepository).deleteById(any(NoteId.class));
+    }
+}

--- a/src/test/java/com/example/notes/infrastructure/adapter/in/rest/NoteRestAdapterTest.java
+++ b/src/test/java/com/example/notes/infrastructure/adapter/in/rest/NoteRestAdapterTest.java
@@ -4,6 +4,8 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
+
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
@@ -11,6 +13,19 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 
 @QuarkusTest
 public class NoteRestAdapterTest {
+
+    private String createNoteAndGetId() {
+        String requestBody = "{\"title\": \"Test\", \"content\": \"Content\", \"tags\": []}";
+        return given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+        .when()
+            .post("/v1/notes")
+        .then()
+            .statusCode(201)
+            .extract()
+            .path("id");
+    }
 
     @Test
     public void testCreateNote() {
@@ -162,5 +177,37 @@ public class NoteRestAdapterTest {
             .statusCode(201)
             .contentType(ContentType.JSON)
             .body("tags.size()", is(0));
+    }
+
+    @Test
+    public void testDeleteExistingNoteReturns204() {
+        String noteId = createNoteAndGetId();
+
+        given()
+        .when()
+            .delete("/v1/notes/" + noteId)
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    public void testDeleteNonExistentNoteReturns404() {
+        UUID nonExistentId = UUID.randomUUID();
+
+        given()
+        .when()
+            .delete("/v1/notes/" + nonExistentId)
+        .then()
+            .statusCode(404)
+            .body("message", is("Note not found with id: " + nonExistentId));
+    }
+
+    @Test
+    public void testDeleteWithInvalidUuidFormatReturns404() {
+        given()
+        .when()
+            .delete("/v1/notes/invalid-uuid")
+        .then()
+            .statusCode(404);
     }
 }


### PR DESCRIPTION
## Summary
- Add DELETE endpoint to delete a Note by its UUID ID following hexagonal architecture
- Returns 204 No Content on success, 404 Not Found if note doesn't exist
- Includes comprehensive unit and integration tests

## Changes
- **Domain Layer**: Added `NoteNotFoundException` for missing notes
- **Application Layer**: Created `DeleteNoteUseCase` port in, added `existsById` and `deleteById` to `NoteRepository` port out
- **Infrastructure**: Implemented repository methods in `JpaNoteRepository`, added exception mapper for 404 responses
- **REST Adapter**: Added DELETE endpoint at `/v1/notes/{id}`

## Test plan
- [x] Unit tests for `NoteApplicationService` delete functionality
- [x] Integration tests for DELETE endpoint (204 success, 404 not found, invalid UUID)
- [x] All 46 tests pass

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now delete notes via the REST API using the DELETE endpoint.
  * Returns HTTP 204 No Content upon successful deletion.
  * Returns HTTP 404 with error message when attempting to delete a non-existent note.

* **Tests**
  * Added comprehensive test coverage for note deletion functionality and error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->